### PR TITLE
Deal with disable option on create

### DIFF
--- a/ui/widgets/accordion.js
+++ b/ui/widgets/accordion.js
@@ -174,17 +174,19 @@ return $.widget( "ui.accordion", {
 				this._createIcons();
 			}
 		}
+	},
+
+	_setOptionDisabled: function( value ) {
+		this._super( value );
+
+		this.element.attr( "aria-disabled", value );
 
 		// Support: IE8 Only
 		// #5332 / #6059 - opacity doesn't cascade to positioned elements in IE
 		// so we need to add the disabled class to the headers and panels
-		if ( key === "disabled" ) {
-			this.element.attr( "aria-disabled", value );
-
-			this._toggleClass( null, "ui-state-disabled", !!value );
-			this._toggleClass( this.headers.add( this.headers.next() ), null, "ui-state-disabled",
-				!!value );
-		}
+		this._toggleClass( null, "ui-state-disabled", !!value );
+		this._toggleClass( this.headers.add( this.headers.next() ), null, "ui-state-disabled",
+			!!value );
 	},
 
 	_keydown: function( event ) {

--- a/ui/widgets/dialog.js
+++ b/ui/widgets/dialog.js
@@ -129,6 +129,11 @@ $.widget( "ui.dialog", {
 			this.options.title = this.originalTitle;
 		}
 
+		// Dialogs can't be disabled
+		if ( this.options.disabled ) {
+			this.options.disabled = false;
+		}
+
 		this._createWrapper();
 
 		this.element

--- a/ui/widgets/draggable.js
+++ b/ui/widgets/draggable.js
@@ -78,9 +78,6 @@ $.widget( "ui.draggable", $.ui.mouse, {
 		if ( this.options.addClasses ) {
 			this._addClass( "ui-draggable" );
 		}
-		if ( this.options.disabled ) {
-			this._addClass( "ui-draggable-disabled" );
-		}
 		this._setHandleClassName();
 
 		this._mouseInit();

--- a/ui/widgets/menu.js
+++ b/ui/widgets/menu.js
@@ -71,11 +71,6 @@ return $.widget( "ui.menu", {
 				tabIndex: 0
 			} );
 
-		if ( this.options.disabled ) {
-			this._addClass( null, "ui-state-disabled" );
-			this.element.attr( "aria-disabled", "true" );
-		}
-
 		this._addClass( "ui-menu", "ui-widget ui-widget-content" );
 		this._on( {
 
@@ -359,11 +354,14 @@ return $.widget( "ui.menu", {
 			this._removeClass( icons, null, this.options.icons.submenu )
 				._addClass( icons, null, value.submenu );
 		}
-		if ( key === "disabled" ) {
-			this.element.attr( "aria-disabled", value );
-			this._toggleClass( null, "ui-state-disabled", !!value );
-		}
 		this._super( key, value );
+	},
+
+	_setOptionDisabled: function( value ) {
+		this._super( value );
+
+		this.element.attr( "aria-disabled", String( value ) );
+		this._toggleClass( null, "ui-state-disabled", !!value );
 	},
 
 	focus: function( event, item ) {

--- a/ui/widgets/progressbar.js
+++ b/ui/widgets/progressbar.js
@@ -117,11 +117,14 @@ return $.widget( "ui.progressbar", {
 			// Don't allow a max less than min
 			value = Math.max( this.min, value );
 		}
-		if ( key === "disabled" ) {
-			this.element.attr( "aria-disabled", value );
-			this._toggleClass( null, "ui-state-disabled", !!value );
-		}
 		this._super( key, value );
+	},
+
+	_setOptionDisabled: function( value ) {
+		this._super( value );
+
+		this.element.attr( "aria-disabled", value );
+		this._toggleClass( null, "ui-state-disabled", !!value );
 	},
 
 	_percentage: function() {

--- a/ui/widgets/selectmenu.js
+++ b/ui/widgets/selectmenu.js
@@ -79,10 +79,6 @@ return $.widget( "ui.selectmenu", {
 
 		this._rendered = false;
 		this.menuItems = $();
-
-		if ( this.options.disabled ) {
-			this.disable();
-		}
 	},
 
 	_drawButton: function() {
@@ -562,22 +558,24 @@ return $.widget( "ui.selectmenu", {
 			this.menuWrap.appendTo( this._appendTo() );
 		}
 
-		if ( key === "disabled" ) {
-			this.menuInstance.option( "disabled", value );
-			this.button.attr( "aria-disabled", value );
-			this._toggleClass( this.button, null, "ui-state-disabled", value );
-
-			this.element.prop( "disabled", value );
-			if ( value ) {
-				this.button.attr( "tabindex", -1 );
-				this.close();
-			} else {
-				this.button.attr( "tabindex", 0 );
-			}
-		}
-
 		if ( key === "width" ) {
 			this._resizeButton();
+		}
+	},
+
+	_setOptionDisabled: function( value ) {
+		this._super( value );
+
+		this.menuInstance.option( "disabled", value );
+		this.button.attr( "aria-disabled", value );
+		this._toggleClass( this.button, null, "ui-state-disabled", value );
+
+		this.element.prop( "disabled", value );
+		if ( value ) {
+			this.button.attr( "tabindex", -1 );
+			this.close();
+		} else {
+			this.button.attr( "tabindex", 0 );
 		}
 	},
 

--- a/ui/widgets/slider.js
+++ b/ui/widgets/slider.js
@@ -81,7 +81,6 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			"ui-widget ui-widget-content" );
 
 		this._refresh();
-		this._setOption( "disabled", this.options.disabled );
 
 		this._animateOff = false;
 	},
@@ -430,10 +429,6 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			valsLength = this.options.values.length;
 		}
 
-		if ( key === "disabled" ) {
-			this._toggleClass( null, "ui-state-disabled", !!value );
-		}
-
 		this._super( key, value );
 
 		switch ( key ) {
@@ -479,6 +474,12 @@ return $.widget( "ui.slider", $.ui.mouse, {
 				this._animateOff = false;
 				break;
 		}
+	},
+
+	_setOptionDisabled: function( value ) {
+		this._super( value );
+
+		this._toggleClass( null, "ui-state-disabled", !!value );
 	},
 
 	//internal value getter

--- a/ui/widgets/spinner.js
+++ b/ui/widgets/spinner.js
@@ -268,11 +268,6 @@ $.widget( "ui.spinner", {
 				this.uiSpinner.height() > 0 ) {
 			this.uiSpinner.height( this.uiSpinner.height() );
 		}
-
-		// Disable spinner if element was already disabled
-		if ( this.options.disabled ) {
-			this.disable();
-		}
 	},
 
 	_keydown: function( event ) {
@@ -427,12 +422,14 @@ $.widget( "ui.spinner", {
 		}
 
 		this._super( key, value );
+	},
 
-		if ( key === "disabled" ) {
-			this._toggleClass( this.uiSpinner, null, "ui-state-disabled", !!value );
-			this.element.prop( "disabled", !!value );
-			this.buttons.button( value ? "disable" : "enable" );
-		}
+	_setOptionDisabled: function( value ) {
+		this._super( value );
+
+		this._toggleClass( this.uiSpinner, null, "ui-state-disabled", !!value );
+		this.element.prop( "disabled", !!value );
+		this.buttons.button( value ? "disable" : "enable" );
 	},
 
 	_setOptions: spinnerModifer( function( options ) {

--- a/ui/widgets/tabs.js
+++ b/ui/widgets/tabs.js
@@ -291,13 +291,6 @@ $.widget( "ui.tabs", {
 			return;
 		}
 
-		if ( key === "disabled" ) {
-
-			// don't use the widget factory's disabled handling
-			this._setupDisabled( value );
-			return;
-		}
-
 		this._super( key, value );
 
 		if ( key === "collapsible" ) {
@@ -363,7 +356,7 @@ $.widget( "ui.tabs", {
 	},
 
 	_refresh: function() {
-		this._setupDisabled( this.options.disabled );
+		this._setOptionDisabled( this.options.disabled );
 		this._setupEvents( this.options.event );
 		this._setupHeightStyle( this.options.heightStyle );
 
@@ -507,7 +500,7 @@ $.widget( "ui.tabs", {
 			.data( "ui-tabs-destroy", true );
 	},
 
-	_setupDisabled: function( disabled ) {
+	_setOptionDisabled: function( disabled ) {
 		var currentItem, li, i;
 
 		if ( $.isArray( disabled ) ) {
@@ -531,6 +524,9 @@ $.widget( "ui.tabs", {
 		}
 
 		this.options.disabled = disabled;
+
+		this._toggleClass( this.widget(), this.widgetFullName + "-disabled", null,
+			disabled === true );
 	},
 
 	_setupEvents: function( event ) {
@@ -804,7 +800,7 @@ $.widget( "ui.tabs", {
 				} );
 			}
 		}
-		this._setupDisabled( disabled );
+		this._setOptionDisabled( disabled );
 	},
 
 	disable: function( index ) {
@@ -826,7 +822,7 @@ $.widget( "ui.tabs", {
 				disabled = [ index ];
 			}
 		}
-		this._setupDisabled( disabled );
+		this._setOptionDisabled( disabled );
 	},
 
 	load: function( index, event ) {

--- a/ui/widgets/tooltip.js
+++ b/ui/widgets/tooltip.js
@@ -105,10 +105,6 @@ $.widget( "ui.tooltip", {
 		// IDs of parent tooltips where we removed the title attribute
 		this.parents = {};
 
-		if ( this.options.disabled ) {
-			this._disable();
-		}
-
 		// Append the aria-live region so tooltips announce correctly
 		this.liveRegion = $( "<div>" )
 			.attr( {
@@ -123,14 +119,6 @@ $.widget( "ui.tooltip", {
 	_setOption: function( key, value ) {
 		var that = this;
 
-		if ( key === "disabled" ) {
-			this[ value ? "_disable" : "_enable" ]();
-			this.options[ key ] = value;
-
-			// disable element style changes
-			return;
-		}
-
 		this._super( key, value );
 
 		if ( key === "content" ) {
@@ -138,6 +126,10 @@ $.widget( "ui.tooltip", {
 				that._updateContent( tooltipData.element );
 			} );
 		}
+	},
+
+	_setOptionDisabled: function( value ) {
+		this[ value ? "_disable" : "_enable" ]();
 	},
 
 	_disable: function() {


### PR DESCRIPTION
Building on top of gh-1599, this fixes missing or redundant handling of the disabled option on create. The only missing widget is tabs. From my comment on the original PR:

> Tabs is not working correctly, for example it ends up with the ui-tabs-disabled class when only setting specific tabs, like disabled: [1, 2]. Due to the array variant I haven't yet figured out what to do here.
